### PR TITLE
Add serial number configuration for drives

### DIFF
--- a/bin/kvmadm
+++ b/bin/kvmadm
@@ -415,6 +415,7 @@ for each disk the following properties can be set:
  optional
      boot
      media
+     serial
      disk_size
      block_size
      cache

--- a/lib/KVMadm/Config.pm
+++ b/lib/KVMadm/Config.pm
@@ -189,6 +189,12 @@ my $SCHEMA = sub {
                 example     => '"index" : "0"',
                 validator   => $sv->regexp(qr/^\d+$/),
             },
+            serial  => {
+                optional    => 1,
+                description => 'serial number of disk, upper-case alpha-numeric, up to 20 characters',
+                example     => '"serial" : "XYZ123"',
+                validator   => $sv->regexp(qr/^[\d[:upper:]]{1,20}$/),
+            },
             boot    => {
                 optional    => 1,
                 description => 'set disk as boot device',
@@ -709,6 +715,7 @@ sub getKVMCmdArray {
             . ',if='    . ($disk->{model} // 'ide')
             . ',media=' . ($disk->{media} // 'disk')
             . ',index=' . $disk->{index}
+            . ',serial=' . ($disk->{serial} // $disk->{index})
             . ',cache=' . ($disk->{cache} // 'none')
             . ($disk->{boot} && $disk->{boot} eq 'true' ? ',boot=on' : ''));
     }


### PR DESCRIPTION
It's bothered me for a while that running OmniOS under KVM with more than one disk results in only one of the disks showing up in the output of `diskinfo`.

After a bit of traipse through user-land libraries and into the kernel, it turns out that a `virtio` drive is given a device ID derived from its serial number, and that `libdiskmgmt` uses the device ID to determine whether it has already seen a drive (in order to ignore slices for one thing).

Without setting a serial number for a virtio drive, all disks have the same devid and therefore don't show up.

This patch adds the 'serial' attribute for a drive and, if it is not set, uses the drive index as the serial number. This is sufficient to ensure that each drive gets a unique device ID in the kernel.

With the result:
```
r151024% pfexec diskinfo
TYPE    DISK                    VID      PID              SIZE          RMV SSD
-       c2t0d0                  Virtio   Block Device      300.00 GiB   no  no
-       c4t0d0                  Virtio   Block Device        8.00 GiB   no  no
```

```
r151024% iostat -En
c2t0d0           Soft Errors: 0 Hard Errors: 0 Transport Errors: 0
Vendor: Virtio Product: Block Device Revision: 0000 Serial No: ETC0M3H0M3
Size: 322.12GB <322122547200 bytes>
Media Error: 0 Device Not Ready: 0 No Device: 0 Recoverable: 0
Illegal Request: 0 Predictive Failure Analysis: 0
c4t0d0           Soft Errors: 0 Hard Errors: 0 Transport Errors: 0
Vendor: Virtio Product: Block Device Revision: 0000 Serial No: HONALULU
Size: 8.59GB <8589934592 bytes>
```