### PR TITLE
Wrong object being passed to writeArray

### DIFF
--- a/lib/KVMadm/Config.pm
+++ b/lib/KVMadm/Config.pm
@@ -581,7 +581,7 @@ sub writeConfig {
 
     # write section configs
     for my $section (@{$SECTIONS->()}) {
-        $self->$writeArray($kvmName, $section, $config->{$section}, $config);
+        $self->$writeArray($kvmName, $section, $config->{$section}, $zConf);
         delete $config->{$section};
     }
 


### PR DESCRIPTION
The config hash is passed instead of $zConf, causing writeArray to consider everything as a zone.