### PR TITLE
Allow hyphens in disk serial numbers

### DIFF
--- a/lib/KVMadm/Config.pm
+++ b/lib/KVMadm/Config.pm
@@ -193,7 +193,7 @@ my $SCHEMA = sub {
                 optional    => 1,
                 description => 'serial number of disk, upper-case alpha-numeric, up to 20 characters',
                 example     => '"serial" : "XYZ123"',
-                validator   => $sv->regexp(qr/^[\dA-Z]{1,20}$/),
+                validator   => $sv->regexp(qr/^[\dA-Z-]{1,20}$/),
             },
             boot    => {
                 optional    => 1,


### PR DESCRIPTION
This is necessary to manually set a disk serial number to the same value that is used by other hypervisors such as bhyve, to allow for dual-booting or migrating KVM instances.